### PR TITLE
User-configurable threading use

### DIFF
--- a/Rinsen.WebServer/ServerBase.cs
+++ b/Rinsen.WebServer/ServerBase.cs
@@ -16,6 +16,17 @@ namespace Rinsen.WebServer
         private readonly ServerContext _serverContext;
         private readonly RouteGenerator _routeGenerator;
         private IExceptionHandler _exceptionHandler;
+		
+		public bool ThreadedResponses {
+			get
+			{
+				return _serverContext.ThreadedReponses;
+			}
+			set
+			{
+				_serverContext.ThreadedReponses = value;
+			}
+		}
 
         public ServerBase()
         {

--- a/Rinsen.WebServer/ServerContext.cs
+++ b/Rinsen.WebServer/ServerContext.cs
@@ -40,5 +40,7 @@ namespace Rinsen.WebServer
         public string DefaultMethodName { get; set; }
 
         public string HostName { get; set; }
+		
+		internal bool ThreadedResponses { get; set; }
     }
 }

--- a/Rinsen.WebServer/SocketListener.cs
+++ b/Rinsen.WebServer/SocketListener.cs
@@ -21,7 +21,7 @@ namespace Rinsen.WebServer
             while (true)
             {
                 var socket = serverSocket.Accept();
-                ProcessClientRequest(socket, true);
+                ProcessClientRequest(socket, _serverContext.ThreadedResponses);
             }
         }
 


### PR DESCRIPTION
On my N+2 running some process-critical code, I find that the webserver has the ability to seriously hamper performance or even hang the CLR.  This is a serious issue when the N+2 is also controlling 120vac heating elements for a reflow oven.  My fix is to make the response handler support configurable multi/single-threaded responses via a property set on ServerBase and propagated via ServerContext.
